### PR TITLE
Use DCIM directory when preparing

### DIFF
--- a/crop-me/src/main/java/com/mikelau/croperino/CroperinoFileUtil.java
+++ b/crop-me/src/main/java/com/mikelau/croperino/CroperinoFileUtil.java
@@ -37,7 +37,8 @@ public class CroperinoFileUtil {
     public static void setupDirectory(Context ctx) {
         String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state)) {
-            mFileTemp = new File(Environment.getExternalStorageDirectory() + CroperinoConfig.getsDirectory(), CroperinoConfig.getsImageName());
+            mFileTemp = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM) + CroperinoConfig.getsDirectory(),
+                    CroperinoConfig.getsImageName());
         } else {
             mFileTemp = new File(ctx.getFilesDir(), CroperinoConfig.getsImageName());
         }


### PR DESCRIPTION
## Description
I think there was an inconsistency between preparing and shooting directories after my last PR.
Here I suggest to use `Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)` in both cases.