### PR TITLE
Fixed replace original image with cropped

### DIFF
--- a/crop-me/src/main/java/com/mikelau/croperino/CropImage.java
+++ b/crop-me/src/main/java/com/mikelau/croperino/CropImage.java
@@ -122,7 +122,7 @@ public class CropImage extends MonitoredActivity {
 
             mImagePath = extras.getString(IMAGE_PATH);
 
-            mSaveUri = getImageUri(mImagePath);
+            mSaveUri = Uri.fromFile(new File(CroperinoConfig.getsRawDirectory()+CroperinoConfig.getsImageName()));
             mBitmap = getBitmap(mImagePath);
 
             if (extras.containsKey(ASPECT_X) && extras.get(ASPECT_X) instanceof Integer) {


### PR DESCRIPTION
When you crop an image, it replaces the original, and if you try to crop the image again, it will decrease.
The correction consists of saving the cropped image to another address
