### PR TITLE
Allowing user specified orientation in crop activity

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-croperino

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -7,5 +7,6 @@
       <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
     </inspection_tool>
+    <inspection_tool class="ResourceType" enabled="false" level="ERROR" enabled_by_default="false" />
   </profile>
 </component>

--- a/app/src/main/java/com/mikelau/cropme/MainActivity.java
+++ b/app/src/main/java/com/mikelau/cropme/MainActivity.java
@@ -17,8 +17,6 @@ import com.mikelau.croperino.Croperino;
 import com.mikelau.croperino.CroperinoConfig;
 import com.mikelau.croperino.CroperinoFileUtil;
 
-import java.io.File;
-
 public class MainActivity extends AppCompatActivity {
 
     private Button btnSummon;
@@ -60,13 +58,13 @@ public class MainActivity extends AppCompatActivity {
         switch (requestCode) {
             case CroperinoConfig.REQUEST_TAKE_PHOTO:
                 if (resultCode == Activity.RESULT_OK) {
-                    Croperino.runCropImage(CroperinoFileUtil.getmFileTemp(), MainActivity.this, true, 1, 1, 0, 0);
+                    Croperino.runCropImage(CroperinoFileUtil.getmFileTemp(), MainActivity.this, true, 1, 1, 0, 0, Croperino.ScreenOrientation.SCREEN_ORIENTATION_LANDSCAPE);
                 }
                 break;
             case CroperinoConfig.REQUEST_PICK_FILE:
                 if (resultCode == Activity.RESULT_OK) {
                     CroperinoFileUtil.newGalleryFile(data, MainActivity.this);
-                    Croperino.runCropImage(CroperinoFileUtil.getmFileTemp(), MainActivity.this, true, 1, 1, 0, 0);
+                    Croperino.runCropImage(CroperinoFileUtil.getmFileTemp(), MainActivity.this, true, 1, 1, 0, 0, Croperino.ScreenOrientation.SCREEN_ORIENTATION_LANDSCAPE);
                 }
                 break;
             case CroperinoConfig.REQUEST_CROP_PHOTO:

--- a/crop-me/src/main/AndroidManifest.xml
+++ b/crop-me/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:name=".CropImage"
             android:configChanges="keyboardHidden|orientation"
             android:label="@string/app_name"
-            android:screenOrientation="portrait" />
+            />
 
         <provider
             android:name="android.support.v4.content.FileProvider"

--- a/crop-me/src/main/java/com/mikelau/croperino/CropImage.java
+++ b/crop-me/src/main/java/com/mikelau/croperino/CropImage.java
@@ -20,6 +20,8 @@ package com.mikelau.croperino;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -91,6 +93,7 @@ public class CropImage extends MonitoredActivity {
 
     private boolean mScaleUp = true;
     private final BitmapManager.ThreadSet mDecodingThreads = new BitmapManager.ThreadSet();
+    private int mScreenOrientation;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -147,7 +150,7 @@ public class CropImage extends MonitoredActivity {
         }
 
         assert extras != null;
-        if(extras.getInt("color") != 0) {
+        if (extras.getInt("color") != 0) {
             findViewById(R.id.discard).setBackgroundColor(extras.getInt("color"));
             findViewById(R.id.save).setBackgroundColor(extras.getInt("color"));
             findViewById(R.id.rotateLeft).setBackgroundColor(extras.getInt("color"));
@@ -155,8 +158,13 @@ public class CropImage extends MonitoredActivity {
             findViewById(R.id.rl_main).setBackgroundColor(extras.getInt("color"));
         }
 
-        if(extras.getInt("bgColor") != 0) {
+        if (extras.getInt("bgColor") != 0) {
             mImageView.setBackgroundColor(extras.getInt("bgColor"));
+        }
+
+        mScreenOrientation = extras.getInt("orientation");
+        if (mScreenOrientation != -1) {
+            setRequestedOrientation(mScreenOrientation);
         }
 
         // Make UI fullscreen.

--- a/crop-me/src/main/java/com/mikelau/croperino/Croperino.java
+++ b/crop-me/src/main/java/com/mikelau/croperino/Croperino.java
@@ -20,7 +20,37 @@ import java.io.IOException;
  */
 public class Croperino {
 
-    public static void runCropImage(File file, Activity ctx, boolean isScalable, int aspectX, int aspectY, int color, int bgColor) {
+    public enum ScreenOrientation {
+
+        SCREEN_ORIENTATION_BEHIND(3),
+        SCREEN_ORIENTATION_FULL_SENSOR(10),
+        SCREEN_ORIENTATION_FULL_USER(13),
+        SCREEN_ORIENTATION_LANDSCAPE(0),
+        SCREEN_ORIENTATION_LOCKED(14),
+        SCREEN_ORIENTATION_NOSENSOR(5),
+        SCREEN_ORIENTATION_PORTRAIT(1),
+        SCREEN_ORIENTATION_REVERSE_LANDSCAPE(8),
+        SCREEN_ORIENTATION_REVERSE_PORTRAIT(9),
+        SCREEN_ORIENTATION_SENSOR(4),
+        SCREEN_ORIENTATION_SENSOR_LANDSCAPE(6),
+        SCREEN_ORIENTATION_SENSOR_PORTRAIT(7),
+        SCREEN_ORIENTATION_UNSPECIFIED(-1),
+        SCREEN_ORIENTATION_USER(2),
+        SCREEN_ORIENTATION_USER_LANDSCAPE(11),
+        SCREEN_ORIENTATION_USER_PORTRAIT(12);
+
+        private final int value;
+
+        ScreenOrientation(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public static void runCropImage(File file, Activity ctx, boolean isScalable, int aspectX, int aspectY, int color, int bgColor, ScreenOrientation screenOrientation) {
         Intent intent = new Intent(ctx, CropImage.class);
         intent.putExtra(CropImage.IMAGE_PATH, file.getPath());
         intent.putExtra(CropImage.SCALE, isScalable);
@@ -28,6 +58,7 @@ public class Croperino {
         intent.putExtra(CropImage.ASPECT_Y, aspectY);
         intent.putExtra("color", color);
         intent.putExtra("bgColor", bgColor);
+        intent.putExtra("orientation", screenOrientation.getValue());
         ctx.startActivityForResult(intent, CroperinoConfig.REQUEST_CROP_PHOTO);
     }
 


### PR DESCRIPTION
@tpom6oh @ekimual  Currently crop activity is locked to portrait orientation, to make it more flexible with phone and tablet apps it would be better if we can launch crop activity with different orientation parameter. please have a look . I needed to open it up for my application use. Tahnks